### PR TITLE
Add quantity to relations

### DIFF
--- a/app/assets/javascripts/spree/backend/create_relation.js.coffee
+++ b/app/assets/javascripts/spree/backend/create_relation.js.coffee
@@ -2,6 +2,7 @@ class CreateRelation
   constructor: (@addRelationSelector) ->
     @relatedToInputSelector = '#add_related_to_name'
     @relationTypeInputSelector = '#add_type'
+    @quantityInputSelector = '#add_quantity'
     @discountInputSelector = '#add_discount'
     @descriptionInputSelector = '#add_description'
 
@@ -22,6 +23,7 @@ class CreateRelation
         data: {
           'relation[related_to_id]': $(@relatedToInputSelector).val(),
           'relation[relation_type_id]': $(@relationTypeInputSelector).val(),
+          'relation[quantity]' : $(@quantityInputSelector).val(),
           'relation[discount_amount]' : $(@discountInputSelector).val(),
           'relation[description]' : $(@descriptionInputSelector).val()
         }

--- a/app/controllers/spree/admin/relations_controller.rb
+++ b/app/controllers/spree/admin/relations_controller.rb
@@ -66,6 +66,7 @@ module Spree
           :relatable,
           :related_to_id,
           :discount_amount,
+          :quantity,
           :description,
           :relation_type_id,
           :position

--- a/app/controllers/spree/admin/variants/relations_controller.rb
+++ b/app/controllers/spree/admin/variants/relations_controller.rb
@@ -67,6 +67,7 @@ module Spree
             :relatable,
             :related_to_id,
             :discount_amount,
+            :quantity,
             :description,
             :relation_type_id,
             :position

--- a/app/controllers/spree/api/relations_controller.rb
+++ b/app/controllers/spree/api/relations_controller.rb
@@ -58,6 +58,7 @@ module Spree
           :relation_type,
           :relatable,
           :related_to_id,
+          :quantity,
           :discount_amount,
           :description,
           :relation_type_id,

--- a/app/controllers/spree/api/variants/relations_controller.rb
+++ b/app/controllers/spree/api/variants/relations_controller.rb
@@ -59,6 +59,7 @@ module Spree
             :relation_type,
             :relatable,
             :related_to_id,
+            :quantity,
             :discount_amount,
             :description,
             :relation_type_id,

--- a/app/models/spree/relation.rb
+++ b/app/models/spree/relation.rb
@@ -10,6 +10,8 @@ class Spree::Relation < ApplicationRecord
   validates :discount_amount, numericality: true
   validates :discount_amount, numericality: { equal_to: 0 }, if: :bidirectional?
 
+  validates :quantity, numericality: { only_integer: true, greater_than_or_equal_to: 1, allow_nil: true }
+
   after_create :create_inverse, unless: :has_inverse?, if: :bidirectional?
   after_save :update_inverse, if: :bidirectional?
   after_destroy :destroy_inverses,

--- a/app/views/spree/admin/products/_related_products_table.html.erb
+++ b/app/views/spree/admin/products/_related_products_table.html.erb
@@ -2,8 +2,10 @@
   <colgroup>
     <col style="width: 5%" />
     <col style="width: 35%" />
-    <col style="width: 35%" />
-    <col style="width: 20%" />
+    <col style="width: 15%" />
+    <col style="width: 5%" />
+    <col style="width: 30%" />
+    <col style="width: 5%" />
     <col style="width: 5%" />
   </colgroup>
   <thead>
@@ -11,6 +13,7 @@
       <th></th>
       <th><%= I18n.t('spree.name') %></th>
       <th><%= I18n.t('spree.type') %></th>
+      <th><%= I18n.t('spree.quantity') %></th>
       <th><%= I18n.t('spree.description') %></th>
       <th><%= I18n.t('spree.discount_amount') %></th>
       <th class="actions"></th>
@@ -26,7 +29,13 @@
         <td><%= relation.relation_type.name %></td>
         <td>
           <%= form_for relation, url: admin_product_relation_path(relation.relatable, relation) do |f| %>
-            <%= f.text_field :description, class: 'form-control text-center' %>
+            <%= f.number_field :quantity, min: 1, class: 'form-control text-center' %>
+            <%= f.button I18n.t('spree.update'), type: 'submit', class: 'button btn-primary', id: 'update_quantity'  %>
+          <% end %>
+        </td>
+        <td>
+          <%= form_for relation, url: admin_product_relation_path(relation.relatable, relation) do |f| %>
+            <%= f.text_field :description, class: 'form-control text-left' %>
             <%= f.button I18n.t('spree.update'), type: 'submit', class: 'button btn-primary', id: 'update_description' %>
           <% end %>
         </td>

--- a/app/views/spree/admin/products/related.html.erb
+++ b/app/views/spree/admin/products/related.html.erb
@@ -28,6 +28,13 @@
           </div>
         </div>
 
+        <div id="related_product_description" class="col-1">
+          <div class="form-group">
+            <%= label_tag :add_quantity, I18n.t('spree.quantity') %>
+            <%= number_field_tag :add_quantity, 1, min: 1, class: 'form-control text-center' %>
+          </div>
+        </div>
+
         <div id="related_product_description" class="col-3">
           <div class="form-group">
             <%= label_tag :add_description, I18n.t('spree.description') %>
@@ -35,7 +42,7 @@
           </div>
         </div>
 
-        <div id="related_product_discount" class="col-3">
+        <div id="related_product_discount" class="col-2">
           <div class="form-group">
             <%= label_tag :add_discount, I18n.t('spree.discount_amount') %>
             <%= text_field_tag :add_discount, 0.0, class: 'form-control text-center' %>

--- a/app/views/spree/admin/variants/_related.html.erb
+++ b/app/views/spree/admin/variants/_related.html.erb
@@ -24,6 +24,13 @@
           </div>
         </div>
 
+        <div id="related_product_quantity" class="col-1">
+          <div class="form-group">
+            <%= label_tag :add_quantity, I18n.t('spree.quantity') %>
+            <%= number_field_tag :add_quantity, 1, min: 1, class: 'form-control number' %>
+          </div>
+        </div>
+
         <div id="related_product_description" class="col-3">
           <div class="form-group">
             <%= label_tag :add_description, I18n.t('spree.description') %>
@@ -31,7 +38,7 @@
           </div>
         </div>
 
-        <div id="related_product_discount" class="col-3">
+        <div id="related_product_discount" class="col-2">
           <div class="form-group">
             <%= label_tag :add_discount, I18n.t('spree.discount_amount') %>
             <%= text_field_tag :add_discount, 0.0, class: 'form-control text-center' %>

--- a/app/views/spree/admin/variants/_related_products_table.html.erb
+++ b/app/views/spree/admin/variants/_related_products_table.html.erb
@@ -2,8 +2,10 @@
   <colgroup>
     <col style="width: 5%" />
     <col style="width: 35%" />
-    <col style="width: 35%" />
-    <col style="width: 20%" />
+    <col style="width: 15%" />
+    <col style="width: 5%" />
+    <col style="width: 30%" />
+    <col style="width: 5%" />
     <col style="width: 5%" />
   </colgroup>
   <thead>
@@ -11,6 +13,7 @@
       <th></th>
       <th><%= I18n.t('spree.name') %></th>
       <th><%= I18n.t('spree.type') %></th>
+      <th><%= I18n.t('spree.quantity') %></th>
       <th><%= I18n.t('spree.description') %></th>
       <th><%= I18n.t('spree.discount_amount') %></th>
       <th class="actions"></th>
@@ -26,7 +29,13 @@
         <td><%= relation.relation_type.name %></td>
         <td>
           <%= form_for relation, url: admin_product_variant_relation_path(relation.relatable.product, relation.relatable, relation) do |f| %>
-            <%= f.text_field :description, class: 'form-control text-center' %>
+            <%= f.number_field :quantity, min: 1, class: 'form-control text-center' %>
+            <%= f.button I18n.t('spree.update'), type: 'submit', class: 'button btn-primary', id: 'update_quantity' %>
+          <% end %>
+        </td>
+        <td>
+          <%= form_for relation, url: admin_product_variant_relation_path(relation.relatable.product, relation.relatable, relation) do |f| %>
+            <%= f.text_field :description, class: 'form-control text-left' %>
             <%= f.button I18n.t('spree.update'), type: 'submit', class: 'button btn-primary', id: 'update_description' %>
           <% end %>
         </td>

--- a/db/migrate/20230615145058_add_quantity_to_spree_relation.rb
+++ b/db/migrate/20230615145058_add_quantity_to_spree_relation.rb
@@ -1,0 +1,6 @@
+class AddQuantityToSpreeRelation < ActiveRecord::Migration[6.1]
+  def change
+    add_column :spree_relations, :quantity, :integer
+    add_index :spree_relations, :quantity
+  end
+end

--- a/lib/solidus_related_products/testing_support/factories.rb
+++ b/lib/solidus_related_products/testing_support/factories.rb
@@ -2,6 +2,8 @@
 
 FactoryBot.define do
   factory :relation, class: Spree::Relation do
+    quantity { 1 }
+
     trait :from_product_to_product do
       association :relatable, factory: :product
       association :related_to, factory: :product

--- a/spec/controllers/spree/admin/relations_controller_spec.rb
+++ b/spec/controllers/spree/admin/relations_controller_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Spree::Admin::RelationsController, type: :controller do
 
     describe '#update' do
       it 'redirects to product/related url' do
-        put :update, params: { product_id: product.id, id: relation.id, relation: { discount_amount: 2.0, description: 'Related Description' } }
+        put :update, params: { product_id: product.id, id: relation.id, relation: { quantity: 1, discount_amount: 2.0, description: 'Related Description' } }
         expect(response).to redirect_to(spree.admin_product_path(relation.relatable) + '/related')
       end
     end

--- a/spec/controllers/spree/admin/variants/relations_controller_spec.rb
+++ b/spec/controllers/spree/admin/variants/relations_controller_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Spree::Admin::Variants::RelationsController, type: :controller do
 
     describe '#update' do
       it 'redirects to product/related url' do
-        put :update, params: { product_id: product.id, variant_id: variant.id, id: relation.id, relation: { discount_amount: 2.0, description: 'Related Description' } }
+        put :update, params: { product_id: product.id, variant_id: variant.id, id: relation.id, relation: { quantity: 1, discount_amount: 2.0, description: 'Related Description' } }
         expect(response).to redirect_to(spree.edit_admin_product_variant_path(relation.relatable.product, relation.relatable))
       end
     end

--- a/spec/controllers/spree/api/relations_controller_spec.rb
+++ b/spec/controllers/spree/api/relations_controller_spec.rb
@@ -60,12 +60,13 @@ RSpec.describe Spree::Api::RelationsController, type: :controller do
           format: :json,
           product_id: product.id,
           id: relation.id,
-          relation: { discount_amount: 2.0, description: 'Related Description' }
+          relation: { quantity: 2, discount_amount: 2.0, description: 'Related Description' }
         }
         expect {
           put :update, params: params
         }.to change { relation.reload.discount_amount.to_s }.from('0.0').to('2.0')
                                                             .and change { relation.reload.description }.from(nil).to('Related Description')
+                                                            .and change { relation.quantity }.to(2)
       end
     end
 

--- a/spec/controllers/spree/api/variants/relations_controller_spec.rb
+++ b/spec/controllers/spree/api/variants/relations_controller_spec.rb
@@ -63,12 +63,13 @@ RSpec.describe Spree::Api::Variants::RelationsController, type: :controller do
           product_id: product.id,
           variant_id: variant.id,
           id: relation.id,
-          relation: { discount_amount: 2.0, description: 'Related Description' }
+          relation: { quantity: 3, discount_amount: 2.0, description: 'Related Description' }
         }
         expect {
           put :update, params: params
         }.to change { relation.reload.discount_amount.to_s }.from('0.0').to('2.0')
                                                             .and change { relation.reload.description }.from(nil).to('Related Description')
+                                                            .and change { relation.quantity }.to(3)
       end
     end
 

--- a/spec/features/spree/admin/product_relation_spec.rb
+++ b/spec/features/spree/admin/product_relation_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe 'Admin Product Relation', :js do
     within('#add-line-item') do
       select2_search product_relation_type.name, from: 'Type'
       select2_search other_product.name, from: 'Name or SKU'
+      fill_in 'add_quantity', with: 3
       fill_in 'add_description', with: 'Related Products Description'
       fill_in 'add_discount', with: '0.8'
       click_link 'Add'
@@ -32,6 +33,7 @@ RSpec.describe 'Admin Product Relation', :js do
       expect(column_text(2)).to eq other_product.name
       expect(column_text(3)).to eq product_relation_type.name
       expect(page).to have_field('relation_description', with: 'Related Products Description')
+      expect(page).to have_field('relation_quantity', with: '3')
     end
   end
 
@@ -43,6 +45,7 @@ RSpec.describe 'Admin Product Relation', :js do
       select2_search variant_relation_type.name, from: 'Type'
       select2_search other_variant.sku, from: 'Name or SKU'
       fill_in 'add_discount', with: '0.8'
+      fill_in 'add_quantity', with: 4
       fill_in 'add_description', with: 'Related Variants Description'
       click_link 'Add'
     end
@@ -52,6 +55,7 @@ RSpec.describe 'Admin Product Relation', :js do
       expect(column_text(2)).to eq other_variant.name_for_relation
       expect(column_text(3)).to eq variant_relation_type.name
       expect(page).to have_field('relation_description', with: 'Related Variants Description')
+      expect(page).to have_field('relation_quantity', with: '4')
     end
   end
 
@@ -63,6 +67,7 @@ RSpec.describe 'Admin Product Relation', :js do
         related_to: other_product,
         relation_type: product_relation_type,
         discount_amount: 0.5,
+        quantity: 2,
         description: 'Related Description'
       )
     end
@@ -82,6 +87,7 @@ RSpec.describe 'Admin Product Relation', :js do
         expect(column_text(2)).to eq other_product.name
         expect(column_text(3)).to eq product_relation_type.name
         expect(page).to have_field('relation_description', with: 'Related Description')
+        expect(page).to have_field('relation_quantity', with: '2')
       end
     end
 
@@ -93,6 +99,17 @@ RSpec.describe 'Admin Product Relation', :js do
 
       within_row(1) do
         expect(page).to have_field('relation_discount_amount', with: '0.9')
+      end
+    end
+
+    it 'update quantity' do
+      within_row(1) do
+        fill_in 'relation_quantity', with: '3'
+        find('#update_quantity').click
+      end
+
+      within_row(1) do
+        expect(page).to have_field('relation_quantity', with: '3')
       end
     end
 

--- a/spec/features/spree/variant/product_relation_spec.rb
+++ b/spec/features/spree/variant/product_relation_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe 'Admin Variant Relation', :js do
     within('#add-line-item') do
       select2_search product_relation_type.name, from: 'Type'
       select2_search other_product.name, from: 'Name or SKU'
+      fill_in 'add_quantity', with: 22
       fill_in 'add_description', with: 'Related Products Description'
       fill_in 'add_discount', with: '0.8'
       click_link 'Add'
@@ -30,6 +31,7 @@ RSpec.describe 'Admin Variant Relation', :js do
       expect(page).to have_field('relation_discount_amount', with: '0.8')
       expect(column_text(2)).to eq other_product.name
       expect(column_text(3)).to eq product_relation_type.name
+      expect(page).to have_field('relation_quantity', with: '22')
       expect(page).to have_field('relation_description', with: 'Related Products Description')
     end
   end
@@ -41,6 +43,7 @@ RSpec.describe 'Admin Variant Relation', :js do
     within('#add-line-item') do
       select2_search variant_relation_type.name, from: 'Type'
       select2_search other_variant.sku, from: 'Name or SKU'
+      fill_in 'add_quantity', with: 33
       fill_in 'add_description', with: 'Related Variants Description'
       fill_in 'add_discount', with: '0.8'
       click_link 'Add'
@@ -50,6 +53,7 @@ RSpec.describe 'Admin Variant Relation', :js do
       expect(page).to have_field('relation_discount_amount', with: '0.8')
       expect(column_text(2)).to eq other_variant.name_for_relation
       expect(column_text(3)).to eq variant_relation_type.name
+      expect(page).to have_field('relation_quantity', with: '33')
       expect(page).to have_field('relation_description', with: 'Related Variants Description')
     end
   end
@@ -91,6 +95,17 @@ RSpec.describe 'Admin Variant Relation', :js do
 
       within_row(1) do
         expect(page).to have_field('relation_discount_amount', with: '0.9')
+      end
+    end
+
+    it 'update quantity' do
+      within_row(1) do
+        fill_in 'relation_quantity', with: 44
+        find('#update_quantity').click
+      end
+
+      within_row(1) do
+        expect(page).to have_field('relation_quantity', with: '44')
       end
     end
 


### PR DESCRIPTION
It is sometimes helpful to suggest a quantity for related products. E.g.
the number of balls of yarn that are needed to knit a jumper.

This adds a quantity to the relations table and the admin sections are
updated to manage the value as per the description field.

Some basic tests are added inline with the description field.

**Recommend Products tab screenshot:**
![Screenshot from 2023-06-26 14-38-33](https://github.com/watg/solidus_related_products/assets/3398855/2d6cf68c-2e88-4ea6-b8a9-6dbb4ed0f580)

**Variant edit screenshot**
![Screenshot from 2023-06-26 14-38-57](https://github.com/watg/solidus_related_products/assets/3398855/09c3d198-320d-4d7f-86e0-08cd6a85f92a)
