### PR TITLE
Update the relation class methods to use the 'available' scope

### DIFF
--- a/app/decorators/models/solidus_related_products/product/add_relation_methods.rb
+++ b/app/decorators/models/solidus_related_products/product/add_relation_methods.rb
@@ -43,16 +43,14 @@ module SolidusRelatedProducts
 
         def relation_filter_for_products
           Spree::Product.where('spree_products.deleted_at' => nil)
-                        .where('spree_products.available_on IS NOT NULL')
-                        .where('spree_products.available_on <= ?', Time.zone.now)
+                        .available
                         .references(self)
         end
 
         def relation_filter_for_variants
           Spree::Variant.joins(:product)
                         .where('spree_products.deleted_at' => nil)
-                        .where('spree_products.available_on IS NOT NULL')
-                        .where('spree_products.available_on <= ?', Time.zone.now)
+                        .merge(Spree::Product.available)
                         .references(self)
         end
 

--- a/spec/models/spree/product_spec.rb
+++ b/spec/models/spree/product_spec.rb
@@ -62,6 +62,90 @@ RSpec.describe Spree::Product, type: :model do
       end
     end
 
+    describe '.relation_filter_for_products' do
+      subject { described_class.relation_filter_for_products }
+
+      context 'with one product' do
+        before do
+          @product.update available_on: available_on, discontinue_on: discontinue_on
+        end
+
+        context 'the product has an available_on date in the past' do
+          let(:available_on) { 1.day.ago }
+
+          context 'the product has a discontinue_on date of nil' do
+            let(:discontinue_on) { nil }
+
+            it "lists the related product" do
+              expect(subject).to eq [@product]
+            end
+          end
+
+          context 'the product has a discontinue_on date in the past' do
+            let(:discontinue_on) { 1.day.ago }
+
+            it "does not list the product" do
+              expect(subject).to eq []
+            end
+          end
+        end
+
+        context 'the product has an available_on date in the future' do
+          let(:available_on) { 1.day.from_now }
+
+          context 'the product is not discontinued' do
+            let(:discontinue_on) { nil }
+
+            it "does not list the product" do
+              expect(subject).to eq []
+            end
+          end
+        end
+      end
+    end
+
+    describe '.relation_filter_for_variants' do
+      subject { described_class.relation_filter_for_variants }
+
+      context 'a product with one variant' do
+        before do
+          @product.update available_on: available_on, discontinue_on: discontinue_on
+        end
+
+        context 'the product has an available_on date in the past' do
+          let(:available_on) { 1.day.ago }
+
+          context 'the product has a discontinue_on date of nil' do
+            let(:discontinue_on) { nil }
+
+            it "lists the related variant" do
+              expect(subject).to eq [@product.master]
+            end
+          end
+
+          context 'the product has a discontinue_on date in the past' do
+            let(:discontinue_on) { 1.day.ago }
+
+            it "does not list the variant" do
+              expect(subject).to eq []
+            end
+          end
+        end
+
+        context 'the product has an available_on date in the future' do
+          let(:available_on) { 1.day.from_now }
+
+          context 'the product is not discontinued' do
+            let(:discontinue_on) { nil }
+
+            it "does not list the variant" do
+              expect(subject).to eq []
+            end
+          end
+        end
+      end
+    end
+
     describe 'RelationType finders' do
       context 'when the relation applies_to Spree::Product' do
         before do


### PR DESCRIPTION
Solidus now has a 'discontinue_on' field, which should also be respected. It is better to use the Solidus product 'available' scope to check for product availability. This is now added along with matching class tests.